### PR TITLE
Removed package-lock.json from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 mta_archives/
 node_modules/
-package-lock.json
 default-env.json
 .env
 .yo-rc.json

--- a/generators/app/templates/dotgitignore
+++ b/generators/app/templates/dotgitignore
@@ -1,6 +1,5 @@
 mta_archives/
 node_modules/
-package-lock.json
 default-*.json
 .env
 .yo-rc.json
@@ -8,7 +7,6 @@ default-*.json
 coverage/
 gen/
 dist/
-app/*/package-lock.json
 *-content.zip
 manifest-bundle.zip
 connection.properties


### PR DESCRIPTION
According with npm best practice the package-lock.json file should be commited:
https://docs.npmjs.com/cli/v8/configuring-npm/package-lock-json

Removed from generator .gitignore and from dotgitignore