### PR TITLE
Swagger only in production

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -50,9 +50,6 @@
 <% if(applicationLogging){ -%>
     "cf-nodejs-logging-support": "^6",
 <% } -%>
-<% if(swagger){ -%>
-    "cds-swagger-ui-express": "^0.1",
-<% } -%>
 <% if(apiFGCN){ -%>
     "uuid": "^8.3",
 <% } -%>
@@ -63,6 +60,9 @@
     "sqlite3": "^5"
 <% if(hana && ui){ -%>
     ,"@sap/ux-specification": "^1.96.4"
+<% } -%>
+<% if(swagger){ -%>
+    ,"cds-swagger-ui-express": "^0.1"
 <% } -%>
   },
 <% if(hana && ui){ -%>

--- a/generators/app/templates/srv/server.js
+++ b/generators/app/templates/srv/server.js
@@ -1,9 +1,5 @@
 const cds = require('@sap/cds');
 
-<% if(swagger){ -%>
-const cdsSwagger = require('cds-swagger-ui-express');
-<% } -%>
-
 <% if(v2support){ -%>
 const odatav2adapterproxy = require('@sap/cds-odata-v2-adapter-proxy');
 <% } -%>
@@ -11,10 +7,13 @@ const odatav2adapterproxy = require('@sap/cds-odata-v2-adapter-proxy');
 cds.on('bootstrap', app => {
 
 <% if(swagger){ -%>
-    app.use(cdsSwagger({
-        "basePath": "/swagger",
-        "diagram": "true"
-    }));
+    if (process.env.NODE_ENV !== 'production') {
+        const cdsSwagger = require ('cds-swagger-ui-express')
+        app.use(cdsSwagger({
+            "basePath": "/swagger",
+            "diagram": "true"
+        }));
+    }
 <% } -%>
 
 <% if(v2support){ -%>


### PR DESCRIPTION
The package cds-swagger-ui-express is disegned to be a devDependency, for example it requires @sap/cds-dk

Initialization in bootstrap now is similar to documentation:
https://www.npmjs.com/package/cds-swagger-ui-express

Kept the custom basePath /swagger instead of default /$api-doc